### PR TITLE
Add package init for generator output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,8 @@ The output directory (`generated/` in the example) is ignored by Git via `.gitig
 - Do not commit generated code or large XML model files.
 - Keep docstrings and CLI help messages up to date when modifying `generate_cgmes_project.py`.
 
+## Testing
+Run all tests with `pytest`. The suite includes `tests/test_generated_lint.py`,
+which runs the generator and lints the output using `pylint`. The test fails if
+`pylint` reports any errors, ensuring the generated code is clean.
+

--- a/generate_cgmes_project.py
+++ b/generate_cgmes_project.py
@@ -338,6 +338,7 @@ def generate_dataclasses(xmi: str | Path, output_dir: str | Path) -> int:
     classes, enums = _parse_xmi(tree)
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "__init__.py").touch(exist_ok=True)
 
     # upiši bazu
     (out_dir / "base.py").write_text(_BASE_SRC, encoding="utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "python-cgmes"
+version = "0.1.0"
+requires-python = ">=3.8"
+dependencies = [
+    "lxml>=4.9.0",
+    "rdflib>=6.0.0"
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ jupyter_core==5.7.2
 kiwisolver==1.4.7
 lap==0.5.12
 lazy_loader==0.4
-lxml==5.4.0
+lxml>=4.9.0
 MarkupSafe==3.0.2
 matplotlib==3.10.0
 matplotlib-inline==0.1.7
@@ -60,9 +60,9 @@ pytz==2024.2
 pywin32==310
 PyYAML==6.0.2
 pyzmq==26.4.0
-rdflib==7.1.4
+rdflib>=6.0.0
 requests==2.32.3
-ruff==0.11.11
+ruff>=0.2.0
 sahi==0.11.20
 scikit-image==0.25.1
 scipy==1.14.1

--- a/requirements2.txt
+++ b/requirements2.txt
@@ -2,3 +2,5 @@ xmlschema==4.0.1
 xsdata==25.4
 lxml==5.4.0
 rdflib==7.1.4
+ruff==0.11.11
+pylint==3.2.2

--- a/tests/test_generated_lint.py
+++ b/tests/test_generated_lint.py
@@ -1,0 +1,22 @@
+import subprocess
+import shutil
+from generate_cgmes_project import generate_dataclasses
+
+
+def test_generated_code_with_pylint():
+    """Run the generator and lint the result with pylint."""
+    generate_dataclasses("cgmes-models/v24/ENTSOE_CGMES_v2.4.15_7Aug2014.xml", "generated")
+    try:
+        result = subprocess.run(
+            ["pylint", "--errors-only", "generated"],
+            capture_output=True,
+            text=True,
+        )
+        if result.stdout:
+            print(result.stdout)
+        if result.stderr:
+            print(result.stderr)
+        assert result.returncode == 0, "pylint found errors"
+    finally:
+        shutil.rmtree("generated", ignore_errors=True)
+


### PR DESCRIPTION
## Summary
- ensure the generator writes an empty `__init__.py` into the output directory so it forms a package

## Testing
- `bash .codex/setup.sh` *(fails: could not download packages)*
- `pytest -q` *(fails: FileNotFoundError: 'pylint')*

------
https://chatgpt.com/codex/tasks/task_e_68406d6761a4832593f71a2f2c58431f