### PR TITLE
Fix TopologicalNode inheritance and merging

### DIFF
--- a/generate_cgmes_project.py
+++ b/generate_cgmes_project.py
@@ -11,6 +11,14 @@
 * Multipliciteti se čitaju iz atributa `<lowerValue>` / `<upperValue>` bez
   prefiksa.
 * Dodati debug print‑ovi koje možeš isključiti `DEBUG = False`.
+
+UML klase se ponekad ponavljaju u različitim paketima.  Skripta spaja sve
+definicije koje imaju isti XMI ID, a zatim spaja i klase sa istim imenom
+bez obzira na paket.  Atributi i roditelji se objedinjuju tako da konačna
+dataclass uključuje uniju svega što je pronađeno.  Zbog toga npr.
+`TopologicalNode` u generisanom kodu sadrži veze ka `Terminal`,
+`ConnectivityNodeContainer` i drugim klasama, iako nisu sve vidljive u
+jednoj EA perspektivi.
 """
 
 from __future__ import annotations
@@ -571,7 +579,11 @@ def _add(s: URIRef, p: URIRef, v, g: Graph):
 
 def _cli():
     """Parse command line arguments and trigger dataclass generation."""
-    ap = argparse.ArgumentParser(description="Generate CGMES dataclasses from XMI")
+    ap = argparse.ArgumentParser(
+        description=
+        "Generate CGMES dataclasses from XMI. Classes with the same name or "
+        "XMI id are merged so attributes may come from multiple packages."
+    )
     ap.add_argument("xmi")
     ap.add_argument("-o", "--output", required=True)
     args = ap.parse_args()

--- a/generate_cgmes_project.py
+++ b/generate_cgmes_project.py
@@ -315,8 +315,35 @@ def _parse_xmi(tree: etree._ElementTree) -> Tuple[
                         ),
                     )
 
-    # merge attributes and parents across duplicate class definitions
+    # merge attributes and parents across duplicate class definitions by XMI id
     for metas in class_by_id.values():
+        if len(metas) < 2:
+            continue
+        combined_attrs: Dict[str, Attribute] = {}
+        parent_name = None
+        parent_pkg = None
+        doc = None
+        for m in metas:
+            combined_attrs.update(m.attrs)
+            if m.parent and not parent_name:
+                parent_name = m.parent
+                parent_pkg = m.parent_pkg
+            if m.doc and not doc:
+                doc = m.doc
+        for m in metas:
+            for a_name, attr in combined_attrs.items():
+                m.attrs.setdefault(a_name, attr)
+            if parent_name and not m.parent:
+                m.parent = parent_name
+                m.parent_pkg = parent_pkg
+            if doc and not m.doc:
+                m.doc = doc
+
+    # merge classes that share the same name across packages
+    name_groups: Dict[str, List[ClassMeta]] = {}
+    for meta in classes.values():
+        name_groups.setdefault(meta.name, []).append(meta)
+    for metas in name_groups.values():
         if len(metas) < 2:
             continue
         combined_attrs: Dict[str, Attribute] = {}
@@ -395,7 +422,7 @@ def _write_enums(enums: Dict[Tuple[str, ...], EnumMeta], out_dir: Path) -> int:
             lines.append(f"    {lit} = '{lit}'")
         if not meta.literals:
             lines.append("    pass")
-        (pkg_dir / f"{meta.name}.py").write_text("\n".join(lines), encoding="utf-8")
+        (pkg_dir / f"{meta.name}.py").write_text("\n".join(lines) + "\n", encoding="utf-8")
         cnt += 1
     return cnt
 
@@ -438,7 +465,7 @@ def _write_classes(classes: Dict[Tuple[str, ...], ClassMeta], enums: Dict[Tuple[
                 )
         if not meta.attrs:
             lines.append("    pass")
-        (pkg_dir / f"{meta.name}.py").write_text("\n".join(lines), encoding="utf-8")
+        (pkg_dir / f"{meta.name}.py").write_text("\n".join(lines) + "\n", encoding="utf-8")
         cnt += 1
     return cnt
 

--- a/generate_cgmes_project.py
+++ b/generate_cgmes_project.py
@@ -61,6 +61,7 @@ class Attribute:
     is_ref: bool = False
     ref_pkg: Optional[Tuple[str, ...]] = None
     uml_id: Optional[str] = None  # XMI id, for tracking links
+    target_id: Optional[str] = None  # referenced class XMI id
 
 
 @dataclass
@@ -167,6 +168,7 @@ def _parse_xmi(tree: etree._ElementTree) -> Tuple[
     enums: Dict[Tuple[str, ...], EnumMeta] = {}
     class_by_id: Dict[str, List[ClassMeta]] = {}
     enum_by_id: Dict[str, EnumMeta] = {}
+    attr_by_id: Dict[str, Tuple[ClassMeta, Attribute]] = {}
     links: List[LinkData] = []
 
     def walk(elem, pkg_path: List[str]):
@@ -240,7 +242,7 @@ def _parse_xmi(tree: etree._ElementTree) -> Tuple[
                     base_type = by_id.get(type_ref).get("name") if type_ref in by_id else "str"
                     ref_pkg = id_to_pkg.get(type_ref)
                 is_ref = bool(prop.get("association"))
-                target.attrs[a_name] = Attribute(
+                attr = Attribute(
                     a_name,
                     f"cim:{cname}.{a_name}",
                     _ptype(base_type, lower, upper),
@@ -248,7 +250,11 @@ def _parse_xmi(tree: etree._ElementTree) -> Tuple[
                     is_ref,
                     ref_pkg,
                     prop.get(f"{{{XMI_NS}}}id"),
+                    type_ref,
                 )
+                target.attrs[a_name] = attr
+                if attr.uml_id:
+                    attr_by_id[attr.uml_id] = (target, attr)
 
             # generalization
             gen = child.find("generalization")
@@ -292,16 +298,37 @@ def _parse_xmi(tree: etree._ElementTree) -> Tuple[
 
     # associations
     for assoc in root.xpath(".//packagedElement[@xmi:type='uml:Association']", namespaces=NSMAP):
-        ends = assoc.xpath("./ownedEnd")
-        if len(ends) < 2:
+        member_ids = [m.get(f"{{{XMI_NS}}}idref") for m in assoc.xpath("./memberEnd")]
+        owned_map = {e.get(f"{{{XMI_NS}}}id"): e for e in assoc.xpath("./ownedEnd")}
+        if len(member_ids) != 2:
             continue
-        for end in ends:
-            owner_id = end.get("type")
-            target_id = next((e.get("type") for e in ends if e is not end and e.get("type")), None)
-            if owner_id in class_by_id and target_id in class_by_id:
+        for idx, end_id in enumerate(member_ids):
+            other_id = member_ids[1 - idx]
+            if end_id in attr_by_id:
+                # attribute already created when walking class
+                continue
+            if end_id not in owned_map:
+                continue
+            end = owned_map[end_id]
+            target_id = end.get("type")
+            if target_id is None:
+                t_elem = end.find("type")
+                if t_elem is not None:
+                    target_id = t_elem.get(f"{{{XMI_NS}}}idref")
+            if other_id in attr_by_id:
+                owner_class_id = attr_by_id[other_id][1].target_id
+            elif other_id in owned_map:
+                owner_class_id = owned_map[other_id].get("type")
+                if owner_class_id is None:
+                    t_elem = owned_map[other_id].find("type")
+                    if t_elem is not None:
+                        owner_class_id = t_elem.get(f"{{{XMI_NS}}}idref")
+            else:
+                owner_class_id = None
+            if owner_class_id in class_by_id and target_id in class_by_id:
                 target_meta = class_by_id[target_id][0]
                 lower, upper = _mult_from_elem(end)
-                for owner_meta in class_by_id[owner_id]:
+                for owner_meta in class_by_id[owner_class_id]:
                     owner_meta.attrs.setdefault(
                         end.get("name") or target_meta.name,
                         Attribute(
@@ -312,6 +339,7 @@ def _parse_xmi(tree: etree._ElementTree) -> Tuple[
                             True,
                             target_meta.pkg_parts,
                             end.get(f"{{{XMI_NS}}}id"),
+                            target_id,
                         ),
                     )
 
@@ -397,7 +425,7 @@ def _py_imports(meta: ClassMeta, classes: Dict[Tuple[str, ...], ClassMeta], enum
         path = _rel_mod(meta.pkg_parts, meta.parent_pkg, meta.parent)
         imps.add(f"from {path} import {meta.parent}")
     for a in meta.attrs.values():
-        base = re.sub(r"^Optional\[|\]$", "", a.type_)
+        base = re.sub(r"^Optional\[(.*)\]$", r"\1", a.type_)
         base = re.sub(r"^list\[(.*)\]$", r"\1", base)
         if a.ref_pkg:
             if base != meta.name or a.ref_pkg != meta.pkg_parts:


### PR DESCRIPTION
## Summary
- merge class metadata across packages so TopologicalNode inherits from IdentifiedObject
- add newline at end of generated files

## Testing
- `pytest -q` *(fails: pylint found errors)*

------
https://chatgpt.com/codex/tasks/task_e_68408f55be18832588faa691b7fa47b2