### PR TITLE
Fix SvVoltage TopologicalNode reference type

### DIFF
--- a/generate_cgmes_project.py
+++ b/generate_cgmes_project.py
@@ -243,6 +243,15 @@ def _parse_xmi(tree: etree._ElementTree) -> Tuple[
                 elif type_ref in enum_by_id:
                     base_type = enum_by_id[type_ref].name
                     ref_pkg = enum_by_id[type_ref].pkg_parts
+                elif type_ref in by_id:
+                    elem = by_id[type_ref]
+                    kind = elem.get(f"{{{XMI_NS}}}type")
+                    if kind in ("uml:Class", "uml:Enumeration"):
+                        base_type = elem.get("name", "str")
+                        ref_pkg = id_to_pkg.get(type_ref)
+                    else:
+                        base_type = "str"
+                        ref_pkg = None
                 else:
                     base_type = "str"
                     ref_pkg = None

--- a/tests/test_svvoltage.py
+++ b/tests/test_svvoltage.py
@@ -1,0 +1,20 @@
+from generate_cgmes_project import generate_dataclasses
+import importlib
+import shutil
+from typing import get_type_hints
+
+
+def setup_module(module):
+    shutil.rmtree("generated", ignore_errors=True)
+    generate_dataclasses("cgmes-models/v24/ENTSOE_CGMES_v2.4.15_7Aug2014.xml", "generated")
+
+
+def test_svvoltage_topologicalnode_type():
+    sv_mod = importlib.import_module(
+        "generated.EuropeanStandards.CommonGridModelExchangeStandard.StateVariablesProfile.StateVariables.SvVoltage"
+    )
+    tn_mod = importlib.import_module(
+        "generated.EuropeanStandards.CommonGridModelExchangeStandard.StateVariablesProfile.Topology.TopologicalNode"
+    )
+    hints = get_type_hints(sv_mod.SvVoltage, globalns=sv_mod.__dict__, localns=sv_mod.__dict__)
+    assert hints["TopologicalNode_ref"] is tn_mod.TopologicalNode


### PR DESCRIPTION
## Summary
- resolve forward references when parsing CGMES XMI
- add regression test for SvVoltage.TopologicalNode_ref type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415fc70058832587b748b0172fb07a