### PR TITLE
Add test for TopologicalNode base class

### DIFF
--- a/cgmes_generator/parser/xmi.py
+++ b/cgmes_generator/parser/xmi.py
@@ -264,6 +264,20 @@ def parse_xmi(tree: etree._ElementTree) -> Tuple[
 
     for meta in classes.values():
         if (
+            'StateVariablesProfile' in '.'.join(meta.pkg_parts)
+            and meta.name == 'TopologicalNode'
+            and meta.parent is None
+        ):
+            meta.parent = 'IdentifiedObject'
+            meta.parent_pkg = (
+                'EuropeanStandards',
+                'CommonGridModelExchangeStandard',
+                'EquipmentProfile',
+                'Core',
+            )
+
+    for meta in classes.values():
+        if (
             'TopologyProfile' in '.'.join(meta.pkg_parts)
             and meta.name
         ):

--- a/tests/test_topologicalnode.py
+++ b/tests/test_topologicalnode.py
@@ -18,3 +18,14 @@ def test_topologicalnode_inheritance():
     )
     assert issubclass(tp_mod.TopologicalNode, sv_mod.TopologicalNode)
     assert not issubclass(sv_mod.TopologicalNode, tp_mod.TopologicalNode)
+
+
+def test_topologicalnode_identifiedobject_base():
+    """Ensure TopologicalNode derives from IdentifiedObject."""
+    tp_mod = importlib.import_module(
+        "generated.EuropeanStandards.CommonGridModelExchangeStandard.TopologyProfile.Topology.TopologicalNode"
+    )
+    io_mod = importlib.import_module(
+        "generated.EuropeanStandards.CommonGridModelExchangeStandard.EquipmentProfile.Core.IdentifiedObject"
+    )
+    assert issubclass(tp_mod.TopologicalNode, io_mod.IdentifiedObject)


### PR DESCRIPTION
## Summary
- verify TopologyProfile `TopologicalNode` is derived from `IdentifiedObject`
- set `StateVariablesProfile.TopologicalNode` parent to `IdentifiedObject`
- keep existing inheritance check between Topology and StateVariables profiles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841688f6cc0832597c7ffe0e9ce54b6