### PR TITLE
Support abstract UML classes as Protocols

### DIFF
--- a/cgmes_generator/meta.py
+++ b/cgmes_generator/meta.py
@@ -31,6 +31,7 @@ class ClassMeta:
     parent_pkg: Optional[Tuple[str, ...]] = None
     uml_id: Optional[str] = None
     links: List["LinkData"] = field(default_factory=list)
+    is_abstract: bool = False
 
 
 @dataclass

--- a/cgmes_generator/parser/xmi.py
+++ b/cgmes_generator/parser/xmi.py
@@ -143,6 +143,7 @@ def parse_xmi(tree: etree._ElementTree) -> Tuple[
                 c_doc.text if c_doc is not None else None,
                 None,
                 child.get(f"{{{XMI_NS}}}id"),
+                is_abstract=child.get("isAbstract") == "true",
             )
             key = tuple(pkg_path + [cname])
             target = classes.get(key)

--- a/cgmes_generator/writer/classes.py
+++ b/cgmes_generator/writer/classes.py
@@ -24,9 +24,25 @@ def write_classes(classes: Dict[Tuple[str, ...], ClassMeta], enums: Dict[Tuple[s
 
         imports, parent_alias = py_imports(meta)
         lines = imports
-        lines += ["", "@dataclass(init=False)"]
-        parent = parent_alias or "CIMObject"
-        lines.append(f"class {meta.name}({parent}):")
+        parent = parent_alias
+        if meta.is_abstract:
+            parent_meta = None
+            if meta.parent and meta.parent_pkg:
+                parent_meta = classes.get(meta.parent_pkg + (meta.parent,))
+            if parent_meta and parent_meta.is_abstract and parent_alias:
+                bases = f"{parent_alias}, Protocol"
+            else:
+                bases = "Protocol"
+            lines += ["", "@runtime_checkable"]
+            lines.append(f"class {meta.name}({bases}):")
+            parent = None
+        else:
+            lines += ["", "@dataclass(init=False)"]
+            bases = []
+            if parent_alias:
+                bases.append(parent_alias)
+            bases.append("CIMObject")
+            lines.append(f"class {meta.name}({', '.join(bases)}):")
         if meta.doc:
             lines.append(f"    \"\"\"{meta.doc}\"\"\"")
         ordered_attrs = sorted(
@@ -34,21 +50,33 @@ def write_classes(classes: Dict[Tuple[str, ...], ClassMeta], enums: Dict[Tuple[s
             key=lambda a: 0 if not (a.type_.startswith("Optional[") or a.type_.startswith("list[")) else 1,
         )
         for a in ordered_attrs:
-            default = ""
-            if a.type_.startswith("Optional["):
-                default = " = None"
-            elif a.type_.startswith("list["):
-                default = " = field(default_factory=list)"
-            if a.is_ref:
-                lines.append(
-                    f"    {a.name}_ref: {a.type_}{default}  # metadata: cim='{a.cim_path}', mult='{a.multiplicity}'"
-                )
-                if not a.type_.startswith("list["):
-                    lines.append(f"    {a.name}_id: str = None")
+            if meta.is_abstract:
+                if a.is_ref:
+                    lines.append(
+                        f"    {a.name}_ref: {a.type_}  # metadata: cim='{a.cim_path}', mult='{a.multiplicity}'"
+                    )
+                    if not a.type_.startswith("list["):
+                        lines.append(f"    {a.name}_id: str")
+                else:
+                    lines.append(
+                        f"    {a.name}: {a.type_}  # metadata: cim='{a.cim_path}', mult='{a.multiplicity}'"
+                    )
             else:
-                lines.append(
-                    f"    {a.name}: {a.type_}{default}  # metadata: cim='{a.cim_path}', mult='{a.multiplicity}'"
-                )
+                default = ""
+                if a.type_.startswith("Optional["):
+                    default = " = None"
+                elif a.type_.startswith("list["):
+                    default = " = field(default_factory=list)"
+                if a.is_ref:
+                    lines.append(
+                        f"    {a.name}_ref: {a.type_}{default}  # metadata: cim='{a.cim_path}', mult='{a.multiplicity}'"
+                    )
+                    if not a.type_.startswith("list["):
+                        lines.append(f"    {a.name}_id: str = None")
+                else:
+                    lines.append(
+                        f"    {a.name}: {a.type_}{default}  # metadata: cim='{a.cim_path}', mult='{a.multiplicity}'"
+                    )
         if not meta.attrs:
             lines.append("    pass")
         (pkg_dir / f"{meta.name}.py").write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/cgmes_generator/writer/utils.py
+++ b/cgmes_generator/writer/utils.py
@@ -22,12 +22,18 @@ def _rel_mod(src: Tuple[str, ...], dst: Tuple[str, ...], name: str) -> str:
 
 
 def py_imports(meta: ClassMeta) -> Tuple[List[str], str | None]:
-    imps = {
-        "from __future__ import annotations",
-        "from dataclasses import dataclass, field",
-        "from typing import Optional, List",
-        f"from {'.' * (len(meta.pkg_parts) + 1)}base import CIMObject",
-    }
+    imps = {"from __future__ import annotations"}
+    if meta.is_abstract:
+        imps.add("from typing import Protocol, runtime_checkable")
+    else:
+        imps.add("from dataclasses import dataclass, field")
+    needs_typing = any(
+        a.type_.startswith("Optional[") or a.type_.startswith("list[")
+        for a in meta.attrs.values()
+    )
+    if needs_typing:
+        imps.add("from typing import Optional, List")
+    imps.add(f"from {'.' * (len(meta.pkg_parts) + 1)}base import CIMObject")
     parent_alias = meta.parent
     if meta.parent and meta.parent_pkg:
         path = _rel_mod(meta.pkg_parts, meta.parent_pkg, meta.parent)


### PR DESCRIPTION
## Summary
- track `isAbstract` attribute in UML parser and store in `ClassMeta`
- export abstract classes as runtime-checkable protocols
- adjust import generation for protocols
- ensure dataclasses that inherit from protocols also inherit `CIMObject`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684180e38d7c8325b2d4d77c5005bb9e