### PR TITLE
Drop CIMObject base class from generated dataclasses

### DIFF
--- a/cgmes_generator/writer/base_src.py
+++ b/cgmes_generator/writer/base_src.py
@@ -1,42 +1,6 @@
-"""Runtime helpers source code."""
+"""Runtime helpers source code.
 
-BASE_SRC = """from __future__ import annotations
+No shared base classes are currently generated, but this file is kept for
+future expansion."""
 
-from dataclasses import dataclass, field, fields
-from typing import List, Optional
-
-from rdflib import Graph, Literal, Namespace, RDF, URIRef
-
-CIM = Namespace('http://iec.ch/TC57/2013/CIM-schema-cim#')
-
-@dataclass
-class CIMObject:
-    rdf_id: str
-
-    _cim_type: str = 'CIMObject'
-
-    def to_rdf(self, g: Graph) -> URIRef:
-        subj = URIRef(f'#{self.rdf_id}')
-        g.add((subj, RDF.type, CIM[self._cim_type]))
-        g.add((subj, CIM['IdentifiedObject.mRID'], Literal(self.rdf_id)))
-        for f in fields(self):
-            if f.name == 'rdf_id':
-                continue
-            pred = CIM[f.metadata.get('cim', f.name).split('.')[-1]]
-            val = getattr(self, f.name)
-            if val is None:
-                continue
-            if isinstance(val, list):
-                for v in val:
-                    _add(subj, pred, v, g)
-            else:
-                _add(subj, pred, val, g)
-        return subj
-
-
-def _add(s: URIRef, p: URIRef, v, g: Graph):
-    if hasattr(v, 'rdf_id'):
-        g.add((s, p, URIRef(f'#{v.rdf_id}')))
-    else:
-        g.add((s, p, Literal(v)))
-"""
+BASE_SRC = """"""

--- a/cgmes_generator/writer/classes.py
+++ b/cgmes_generator/writer/classes.py
@@ -41,8 +41,10 @@ def write_classes(classes: Dict[Tuple[str, ...], ClassMeta], enums: Dict[Tuple[s
             bases = []
             if parent_alias:
                 bases.append(parent_alias)
-            bases.append("CIMObject")
-            lines.append(f"class {meta.name}({', '.join(bases)}):")
+            if bases:
+                lines.append(f"class {meta.name}({', '.join(bases)}):")
+            else:
+                lines.append(f"class {meta.name}:")
         if meta.doc:
             lines.append(f"    \"\"\"{meta.doc}\"\"\"")
         ordered_attrs = sorted(

--- a/cgmes_generator/writer/utils.py
+++ b/cgmes_generator/writer/utils.py
@@ -33,7 +33,6 @@ def py_imports(meta: ClassMeta) -> Tuple[List[str], str | None]:
     )
     if needs_typing:
         imps.add("from typing import Optional, List")
-    imps.add(f"from {'.' * (len(meta.pkg_parts) + 1)}base import CIMObject")
     parent_alias = meta.parent
     if meta.parent and meta.parent_pkg:
         path = _rel_mod(meta.pkg_parts, meta.parent_pkg, meta.parent)


### PR DESCRIPTION
## Summary
- generator no longer creates CIMObject runtime helper
- dataclasses are written without inheriting from CIMObject
- imports for the former base module have been removed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684183a72e5c8325a3d13708b3b6dafe