### PR TITLE
Fix generator test for venv & commit guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,11 @@ EA XMI  ➜  +---->+  (reference models)  |
 * Each public function ↔ one docstring with example.
 * Update **both** this handbook and `README.md` when behaviour changes.
 
+### 4.6  Commit Message Guidelines
+
+* Start the commit title with the relevant agent code (e.g. `DOC-401`).
+* Include the full pull request summary in the commit body so the intent is clear from `git log` alone.
+
 ---
 
 ## 5  Contributor Checklist (for humans & LLMs)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -3,11 +3,12 @@ import shutil
 from dataclasses import fields
 
 import subprocess
+import sys
 
 
 def setup_module(module):
     shutil.rmtree("generated", ignore_errors=True)
-    subprocess.check_call(["python", "-m", "cgmes_generator", "--rebuild"])
+    subprocess.check_call([sys.executable, "-m", "cgmes_generator", "--rebuild"])
 
 
 def test_topologicalnode_metadata():


### PR DESCRIPTION
## Summary
- use the current Python executable when running the generator in `tests/test_codegen.py`
- document commit message requirements in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d52a0a54832592f67f31127427ea