### PR TITLE
Implement linker.resolve for object references

### DIFF
--- a/runtime/linker.py
+++ b/runtime/linker.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""In-memory reference resolver for CGMES dataclasses."""
+
+from typing import Any, Iterable
+
+
+def resolve(model_objects: Iterable[Any]) -> None:
+    """Resolve ``*_id`` attributes to ``*_ref`` on *model_objects*.
+
+    Objects are indexed by ``mRID`` or ``rdf_ID`` (if present). For every
+    attribute ending with ``_id`` a corresponding ``*_ref`` attribute is
+    looked up in the index and set to the target object. A :class:`KeyError`
+    is raised if the reference target cannot be found.
+    """
+
+    objs = list(model_objects)
+    index: dict[str, Any] = {}
+    for obj in objs:
+        obj_id = getattr(obj, "mRID", None)
+        if obj_id is None:
+            obj_id = getattr(obj, "rdf_ID", None)
+        if obj_id is not None:
+            index[obj_id] = obj
+
+    for obj in objs:
+        for attr in list(vars(obj)):
+            if not attr.endswith("_id"):
+                continue
+            val = getattr(obj, attr)
+            if val is None:
+                continue
+            ref_attr = attr[:-3] + "_ref"
+            if not hasattr(obj, ref_attr):
+                continue
+            target = index.get(val.lstrip("#"))
+            if target is None:
+                raise KeyError(val)
+            setattr(obj, ref_attr, target)

--- a/tests/test_linker.py
+++ b/tests/test_linker.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+import pytest
+from runtime.linker import resolve
+
+
+@dataclass
+class Bus:
+    mRID: str
+
+
+@dataclass
+class Load:
+    mRID: str
+    Bus_id: str | None = None
+    Bus_ref: Bus | None = None
+
+
+def test_resolve_basic():
+    bus = Bus(mRID="B1")
+    load = Load(mRID="L1", Bus_id="#B1")
+    resolve([bus, load])
+    assert load.Bus_ref is bus
+
+
+def test_resolve_missing():
+    load = Load(mRID="L1", Bus_id="#B2")
+    with pytest.raises(KeyError):
+        resolve([load])


### PR DESCRIPTION
## Summary
- add `runtime.linker.resolve` to wire `_id` fields to `_ref` fields
- test resolver success and failure cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e36233ac832595903f9c38e64c64