### PR TITLE
RT-201: add bulk parse helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ for node in parse_file("models/v24/ENTSOE_CGMES_v2.4.15_7Aug2014.xml",
     print(node.mRID, node.name, node.BaseVoltage_id)
 ```
 
+```python
+from cgmes.runtime import parse_dataset
+from cgmes.generated.topology.voltagelevel import VoltageLevel
+
+data = parse_dataset("models/v24/ENTSOE_CGMES_v2.4.15_7Aug2014.xml",
+                     [TopologicalNode, VoltageLevel])
+print(len(data[TopologicalNode]))
+```
+
 *The generator and runtime are dependency‑light:* only `lxml` and the standard library. Large CGMES instance models (100 MB+) can be streamed with `iterparse` in constant memory.
 
 ---

--- a/benchmarks/bench_dataset.py
+++ b/benchmarks/bench_dataset.py
@@ -1,0 +1,31 @@
+"""Benchmark for parse_dataset helper."""
+
+from pathlib import Path
+from runtime.base import parse_dataset
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass(kw_only=True)
+class IdentifiedObject:
+    mRID: str = field(metadata={"xpath": "@rdf:ID"})
+
+
+@dataclass(kw_only=True)
+class Equipment(IdentifiedObject):
+    name: Optional[str] = field(default=None, metadata={"xpath": "cim:IdentifiedObject.name/text()"})
+
+
+DATASET = (
+    Path(__file__).resolve().parent.parent
+    / "cgmes-models"
+    / "v24"
+    / "SmallGrid"
+    / "node-breaker"
+    / "SmallGridTestConfiguration_BC_EQ_v3.0.0.xml"
+)
+
+
+def bench_parse_dataset(benchmark):
+    benchmark(lambda: parse_dataset(str(DATASET), [Equipment]))

--- a/runtime/base.py
+++ b/runtime/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Minimal runtime helpers for CGMES dataclasses."""
 
 from dataclasses import fields
-from typing import Any, ClassVar, Dict, Iterator, List, Tuple, Type, TypeVar
+from typing import Any, Dict, Iterator, List, Tuple, Type, TypeVar
 
 from lxml import etree
 
@@ -100,3 +100,26 @@ def parse_file(path: str, cls: Type[T]) -> Iterator[T]:
     for _event, elem in etree.iterparse(path, events=("end",), tag=tag):
         yield parse_dataclass(elem, cls)
         elem.clear()
+
+
+def parse_dataset(path: str, classes: List[Type[Any]]) -> Dict[Type[Any], List[Any]]:
+    """Parse *path* once and collect objects of ``classes``.
+
+    Example
+    -------
+    >>> data = parse_dataset("model.xml", [TopologicalNode, VoltageLevel])
+    >>> len(data[TopologicalNode])
+    10
+    """
+    qname_map = {f"{{{NS['cim']}}}{cls.__name__}": cls for cls in classes}
+    result: Dict[Type[Any], List[Any]] = {cls: [] for cls in classes}
+    tags = tuple(qname_map)
+    for _event, elem in etree.iterparse(path, events=("end",), tag=tags):
+        cls = qname_map[elem.tag]
+        result[cls].append(parse_dataclass(elem, cls))
+        elem.clear()
+    from . import validation
+
+    validation.validate(result, strict=True)
+    validation.resolve(result)
+    return result

--- a/runtime/validation.py
+++ b/runtime/validation.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Simple validation helpers for CGMES dataclasses."""
+
+from dataclasses import fields
+import re
+from typing import Any, Dict, Iterable, List, Type
+
+
+_Dataset = Dict[Type[Any], List[Any]]
+_hooks: List[callable] = []
+
+
+def add_hook(fn: callable) -> None:
+    """Register a custom validation *fn* executed during :func:`validate`."""
+    _hooks.append(fn)
+
+
+def validate(dataset: _Dataset, *, strict: bool = False) -> None:
+    """Validate objects in *dataset* based on field metadata."""
+    if not strict:
+        return
+    for cls, objs in dataset.items():
+        for obj in objs:
+            for f in fields(cls):
+                if f.metadata.get("required") and getattr(obj, f.name) is None:
+                    raise ValueError(f"{cls.__name__}.{f.name} is required")
+                pattern = f.metadata.get("pattern")
+                value = getattr(obj, f.name)
+                if pattern and value is not None:
+                    if not re.match(pattern, str(value)):
+                        raise ValueError(f"{cls.__name__}.{f.name} does not match {pattern}")
+    for hook in _hooks:
+        hook(dataset)
+
+
+def resolve(dataset: _Dataset) -> None:
+    """Dereference ``*_id`` fields into ``*_ref`` objects within *dataset*."""
+    id_map: Dict[str, Any] = {}
+    for objs in dataset.values():
+        for obj in objs:
+            mrid = getattr(obj, "mRID", None)
+            if mrid is not None:
+                id_map[f"#{mrid}"] = obj
+    for cls, objs in dataset.items():
+        for obj in objs:
+            for f in fields(cls):
+                if f.name.endswith("_id"):
+                    ref_field = f.name[:-3] + "_ref"
+                    target = id_map.get(getattr(obj, f.name))
+                    if hasattr(obj, ref_field):
+                        setattr(obj, ref_field, target)

--- a/tests/test_parse_dataset.py
+++ b/tests/test_parse_dataset.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass, field
+from typing import Optional
+from runtime.base import parse_dataset
+
+
+data_xml = (
+    '<root xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim#" '
+    'xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">'
+    '<cim:VoltageLevel rdf:ID="vl1">'
+    "<cim:IdentifiedObject.name>VL1</cim:IdentifiedObject.name>"
+    "</cim:VoltageLevel>"
+    '<cim:TopologicalNode rdf:ID="tn1">'
+    "<cim:TopologicalNode.name>Node1</cim:TopologicalNode.name>"
+    '<cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#vl1"/>'
+    "</cim:TopologicalNode>"
+    "</root>"
+)
+
+
+@dataclass(kw_only=True)
+class IdentifiedObject:
+    mRID: str = field(metadata={"xpath": "@rdf:ID", "required": True})
+    name: Optional[str] = field(default=None, metadata={"xpath": "cim:IdentifiedObject.name/text()"})
+
+
+@dataclass(kw_only=True)
+class VoltageLevel(IdentifiedObject):
+    pass
+
+
+@dataclass(kw_only=True)
+class TopologicalNode(IdentifiedObject):
+    ConnectivityNodeContainer_id: str = field(
+        metadata={
+            "xpath": "cim:TopologicalNode.ConnectivityNodeContainer/@rdf:resource",
+            "required": True,
+            "pattern": "^#.+$",
+        }
+    )
+    ConnectivityNodeContainer_ref: VoltageLevel | None = field(default=None)
+
+
+def test_parse_dataset(tmp_path):
+    file = tmp_path / "data.xml"
+    file.write_text(data_xml)
+    result = parse_dataset(str(file), [TopologicalNode, VoltageLevel])
+    assert len(result[TopologicalNode]) == 1
+    assert len(result[VoltageLevel]) == 1
+    tn = result[TopologicalNode][0]
+    vl = result[VoltageLevel][0]
+    assert tn.ConnectivityNodeContainer_ref is vl


### PR DESCRIPTION
## Summary
- implement `parse_dataset` for one-pass parsing of multiple classes
- add basic validation & resolve helpers
- document bulk parsing in README
- benchmark dataset loading
- test `parse_dataset`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e374501c8325a103233631abca41