### PR TITLE
Add developer cookbook and SvVoltage example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,8 @@ EA XMI  ➜  +---->+  (reference models)  |
 * [ ] My code is typed and formatted with `black`; `pytest` passes.<br>
 * [ ] I updated or added tests relevant to my changes.<br>
 * [ ] I updated docs (`README.md`, `AGENTS.md`).<br>
-* [ ] `benchmarks.perf` runs within budget.
+* [ ] `benchmarks.perf` runs within budget.<br>
+* [ ] `semantic_validator.py` passes on the reference models.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -124,3 +124,10 @@ The generic runtime can fall back to `iterparse` for true streaming, so RAM stay
 * JSON‑LD exporter for CIM graphs.
 
 Pull requests are welcome – follow the contribution tips in `AGENTS.md`!
+
+## 8  How to add a new CIM element in 3 steps
+
+1. Run `generate_cgmes_project.py` to regenerate models.
+2. Extend the generated dataclasses with the new element and its `xpath`.
+3. Add a test under `tests/` to validate round‑trip parsing.
+

--- a/docs/cookbook/new_element.md
+++ b/docs/cookbook/new_element.md
@@ -1,0 +1,18 @@
+# Adding a New CIM Element
+
+This quick guide shows how to extend **cgmes-py** with a new CIM element. The steps mirror the existing workflow used in the tests.
+
+1. **Regenerate models**
+
+   ```bash
+   python generate_cgmes_project.py
+   ```
+
+2. **Create or update dataclasses**
+
+   Edit the generated model to add the new element with appropriate `xpath` metadata.
+
+3. **Write a test**
+
+   Add a test under `tests/` ensuring the element can be parsed and written back without loss.
+

--- a/examples/list_sv_voltage.py
+++ b/examples/list_sv_voltage.py
@@ -1,0 +1,9 @@
+"""Print SvVoltage magnitudes from the sample model."""
+
+from cgmes.runtime import parse_file
+from cgmes.generated.statevariables.svvoltage import SvVoltage
+
+path = "cgmes-models/v24/SmallGrid/node-breaker/SmallGridTestConfiguration_BC_SV_v3.0.0.xml"
+
+for sv in parse_file(path, SvVoltage):
+    print(sv.v)


### PR DESCRIPTION
## Summary
- add checklist item for semantic validator
- document how to add a new CIM element in README
- create docs/cookbook/new_element.md
- provide SvVoltage listing example

## Testing
- `pytest -q`
- `python -m benchmarks.perf` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6841e398c8b883258929741c62acc04c