### PR TITLE
PERF-302 add benchmark guardrail

### DIFF
--- a/benchmarks/bench_dataset.py
+++ b/benchmarks/bench_dataset.py
@@ -1,0 +1,55 @@
+"""Dataset parsing benchmark for CGMES profiles."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import time
+from pathlib import Path
+
+from generate_cgmes_project import generate_dataclasses
+from runtime.base import parse_file
+
+
+DEFAULT_DIR = Path("cgmes-models/v24/SmallGrid/node-breaker")
+XMI_PATH = "cgmes-models/v24/ENTSOE_CGMES_v2.4.15_7Aug2014.xml"
+
+
+def bench() -> float:
+    """Return objects/s for parsing EQ + SSH files."""
+    bench_dir = Path(os.environ.get("CGMES_BENCH_DIR", DEFAULT_DIR))
+    eq = bench_dir / "SmallGridTestConfiguration_BC_EQ_v3.0.0.xml"
+    tp = bench_dir / "SmallGridTestConfiguration_BC_TP_v3.0.0.xml"
+    sv = bench_dir / "SmallGridTestConfiguration_BC_SV_v3.0.0.xml"
+    ssh = bench_dir / "SmallGridTestConfiguration_BC_SSH_v3.0.0.xml"
+    for f in (eq, tp, sv, ssh):
+        if not f.exists():
+            raise FileNotFoundError(f)
+
+    if not Path("generated").exists():
+        generate_dataclasses(XMI_PATH, "generated")
+
+    tn_mod = importlib.import_module(
+        "generated.EuropeanStandards.CommonGridModelExchangeStandard.TopologyProfile.Topology.TopologicalNode"
+    )
+    sv_mod = importlib.import_module(
+        "generated.EuropeanStandards.CommonGridModelExchangeStandard.StateVariablesProfile.StateVariables.SvVoltage"
+    )
+    TopologicalNode = tn_mod.TopologicalNode
+    SvVoltage = sv_mod.SvVoltage
+
+    count = 0
+    start = time.perf_counter()
+    for file in (eq, tp):
+        for _ in parse_file(str(file), TopologicalNode):
+            count += 1
+    for file in (sv, ssh):
+        for _ in parse_file(str(file), SvVoltage):
+            count += 1
+    elapsed = time.perf_counter() - start
+    return count / elapsed
+
+
+if __name__ == "__main__":
+    thr = bench()
+    print(f"{thr:.2f} objects/s")

--- a/benchmarks/perf.py
+++ b/benchmarks/perf.py
@@ -1,0 +1,19 @@
+"""Run all performance benchmarks and enforce thresholds."""
+
+from __future__ import annotations
+
+from .bench_dataset import bench
+
+
+THRESHOLD = 400_000  # objects per second
+
+
+def main() -> None:
+    thr = bench()
+    if thr < THRESHOLD:
+        raise SystemExit(f"dataset throughput {thr:.0f} < {THRESHOLD} obj/s")
+    print(f"dataset throughput: {thr:.0f} obj/s")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_perf_dataset.py
+++ b/tests/test_perf_dataset.py
@@ -1,0 +1,11 @@
+import os
+import pytest
+
+from benchmarks.perf import main
+
+
+@pytest.mark.perf
+def test_dataset_perf():
+    if not os.environ.get("CGMES_BENCH_DIR"):
+        pytest.skip("benchmark dataset not available")
+    main()


### PR DESCRIPTION
## Summary
- add dataset parsing benchmark with 400k obj/s guardrail
- enforce the benchmark via `benchmarks.perf`
- integrate benchmark with a new perf test

## Testing
- `pytest -k perf -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841e3bc24d4832598c639a135e27fb0