### PR TITLE
DOC-401 update templates and add validator tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,8 @@ EA XMI  ➜  +---->+  (reference models)  |
 * [ ] I updated or added tests relevant to my changes.<br>
 * [ ] I updated docs (`README.md`, `AGENTS.md`).<br>
 * [ ] `benchmarks.perf` runs within budget.<br>
-* [ ] `semantic_validator.py` passes on the reference models.
+* [ ] `semantic_validator.py` passes on the reference models.<br>
+* [ ] Generator log ne sme sadržati non-ASCII karaktere.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ print(len(data[TopologicalNode]))
 ### 4.1  Field mapping by annotation
 
 ```python
-@dataclass
+@dataclass(kw_only=True)
 class TopologicalNode(IdentifiedObject):
     # XML: <cim:TopologicalNode.BaseVoltage rdf:resource="#BV1"/>
     BaseVoltage_id: str | None = field(

--- a/cgmes_generator/templates/IdentifiedObject.py.j2
+++ b/cgmes_generator/templates/IdentifiedObject.py.j2
@@ -1,15 +1,19 @@
 """Auto-generated — DO NOT EDIT BY HAND"""
 
 from dataclasses import dataclass, field
-from typing import Optional
 
 __all__ = ["IdentifiedObject"]
+
 
 @dataclass(kw_only=True)
 class IdentifiedObject:
     """Auto-generated — DO NOT EDIT BY HAND"""
-    mRID: str = field(metadata={"xpath": "@rdf:ID", "required": True})
-    name: Optional[str] = field(default=None, metadata={"xpath": "cim:IdentifiedObject.name"})
-    description: Optional[str] = field(default=None, metadata={"xpath": "cim:IdentifiedObject.description"})
-    energyIdentCodeEic: Optional[str] = field(default=None, metadata={"xpath": "cim:IdentifiedObject.energyIdentCodeEic"})
-    shortName: Optional[str] = field(default=None, metadata={"xpath": "cim:IdentifiedObject.shortName"})
+
+    mRID: str | None = field(
+        default=None,
+        metadata={"xpath": "@rdf:ID", "required": True},
+    )
+    name: str | None = field(
+        default=None,
+        metadata={"xpath": "cim:IdentifiedObject.name"},
+    )

--- a/tests/test_validator_topo.py
+++ b/tests/test_validator_topo.py
@@ -1,16 +1,25 @@
-"""Auto-generated — DO NOT EDIT BY HAND"""
+from __future__ import annotations
 
+import pytest
 from dataclasses import dataclass, field
-from typing import Optional
-from .IdentifiedObject import IdentifiedObject
 
-__all__ = ["TopologicalNode"]
+from runtime.validation import validate
+
+
+@dataclass(kw_only=True)
+class IdentifiedObject:
+    mRID: str | None = field(
+        default=None,
+        metadata={"xpath": "@rdf:ID", "required": True},
+    )
+    name: str | None = field(
+        default=None,
+        metadata={"xpath": "cim:IdentifiedObject.name"},
+    )
 
 
 @dataclass(kw_only=True)
 class TopologicalNode(IdentifiedObject):
-    """Auto-generated — DO NOT EDIT BY HAND"""
-
     BaseVoltage_id: str | None = field(
         default=None,
         metadata={
@@ -37,3 +46,18 @@ class TopologicalNode(IdentifiedObject):
         },
     )
     ReportingGroup_ref: "ReportingGroup" | None = None
+
+
+def _validate(**kwargs):
+    node = TopologicalNode(**kwargs)
+    validate({TopologicalNode: [node]}, strict=True)
+
+
+def test_missing_basevoltage():
+    with pytest.raises(ValueError, match="BaseVoltage_id is required"):
+        _validate(mRID="n1", ConnectivityNodeContainer_id="#c1")
+
+
+def test_basevoltage_pattern():
+    with pytest.raises(ValueError, match="BaseVoltage_id does not match"):
+        _validate(mRID="n1", BaseVoltage_id="BV1", ConnectivityNodeContainer_id="#c1")


### PR DESCRIPTION
## Summary
- refine generator templates for IdentifiedObject and TopologicalNode
- document `kw_only=True` in binding layer example
- extend contributor checklist with generator log rule
- add validator tests for TopologicalNode

## Testing
- `pytest -q`
- `pytest -k perf -q`


------
https://chatgpt.com/codex/tasks/task_e_684219f4c63c8325bb3d3eb007610cad