### PR TITLE
Add SmallGrid node-breaker integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ pip install -r requirements2.txt          # lxml + pytest + pylint
 python generate_cgmes_project.py          # ▶ writes ./generated/
 python examples/roundtrip.py              # ▶ demo: parse + write back
 pytest                                    # ▶ all tests incl. pylint
+pytest -k smallgrid                       # ▶ integration test on sample model
 ```
 
 ```python

--- a/benchmarks/bench_dataset.py
+++ b/benchmarks/bench_dataset.py
@@ -1,7 +1,7 @@
 """Benchmark for parse_dataset helper."""
 
 from pathlib import Path
-from runtime.base import parse_dataset
+from cgmes.runtime import parse_dataset
 
 from dataclasses import dataclass, field
 from typing import Optional
@@ -14,7 +14,9 @@ class IdentifiedObject:
 
 @dataclass(kw_only=True)
 class Equipment(IdentifiedObject):
-    name: Optional[str] = field(default=None, metadata={"xpath": "cim:IdentifiedObject.name/text()"})
+    name: Optional[str] = field(
+        default=None, metadata={"xpath": "cim:IdentifiedObject.name/text()"}
+    )
 
 
 DATASET = (

--- a/cgmes/__init__.py
+++ b/cgmes/__init__.py
@@ -1,11 +1,25 @@
 """cgmes package exposing runtime helpers."""
 
+from importlib import import_module as _imp
 import sys
-from importlib import import_module
 
-runtime = import_module("runtime")
-sys.modules[__name__ + ".runtime"] = runtime
+try:  # optional dependency
+    import pkg_resources
+except ModuleNotFoundError:  # pragma: no cover - fallback when setuptools absent
+    pkg_resources = None
+else:  # pragma: no cover - declare namespace if available
+    pkg_resources.declare_namespace(__name__)
 
-from runtime import parse_file, parse_dataset, to_element, parse_dataclass  # noqa: F401
+_runtime = _imp("runtime")
+sys.modules[__name__ + ".runtime"] = _runtime
 
-__all__ = ["parse_file", "parse_dataset", "to_element", "parse_dataclass", "runtime"]
+from runtime.base import (
+    parse_dataclass,
+    parse_file as _parse_file,
+    parse_dataset,
+    to_element,
+)
+
+parse_file = _parse_file
+
+__all__ = ["parse_file", "parse_dataset", "to_element", "parse_dataclass"]

--- a/cgmes/__init__.py
+++ b/cgmes/__init__.py
@@ -1,0 +1,11 @@
+"""cgmes package exposing runtime helpers."""
+
+import sys
+from importlib import import_module
+
+runtime = import_module("runtime")
+sys.modules[__name__ + ".runtime"] = runtime
+
+from runtime import parse_file, parse_dataset, to_element, parse_dataclass  # noqa: F401
+
+__all__ = ["parse_file", "parse_dataset", "to_element", "parse_dataclass", "runtime"]

--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from functools import wraps
+from pathlib import Path
+from typing import Iterator, Type, TypeVar
+
+from lxml import etree
+
+from .base import parse_dataclass, parse_file as _parse_file, parse_dataset, to_element
+from . import validation
+
+T = TypeVar("T")
+
+
+@wraps(parse_dataclass)
+def _parse_element(elem: etree._Element, cls: Type[T]) -> T:
+    obj = parse_dataclass(elem, cls)
+    validation.validate({cls: [obj]}, strict=True)
+    validation.resolve({cls: [obj]})
+    return obj
+
+
+@wraps(_parse_file)
+def parse_file(source: str | Path | etree._Element, cls: Type[T]) -> Iterator[T] | T:
+    """Parse *source* into ``cls`` objects with strict validation."""
+    if isinstance(source, etree._Element):
+        return _parse_element(source, cls)
+    data = parse_dataset(str(source), [cls])[cls]
+    return iter(data)
+
+
+parse_file.__wrapped__ = _parse_element
+
+
+__all__ = ["parse_file", "parse_dataset", "to_element", "parse_dataclass"]

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1,18 +1,29 @@
 import importlib
 import shutil
 from dataclasses import fields
+import os
 
 import subprocess
 import sys
 
 
 def setup_module(module):
-    subprocess.check_call([sys.executable, "-m", "cgmes_generator", "--rebuild"])
+    env = os.environ.copy()
+    env["PYTHONUTF8"] = "1"
+    subprocess.check_call(
+        [sys.executable, "-m", "cgmes_generator", "--rebuild"],
+        env=env,
+    )
+    importlib.invalidate_caches()
 
 
 def test_topologicalnode_metadata():
-    tn_mod = importlib.import_module("generated.EuropeanStandards.CommonGridModelExchangeStandard.TopologyProfile.Topology.TopologicalNode")
-    base_mod = importlib.import_module("generated.EuropeanStandards.CommonGridModelExchangeStandard.EquipmentProfile.Core.IdentifiedObject")
+    tn_mod = importlib.import_module(
+        "generated.EuropeanStandards.CommonGridModelExchangeStandard.TopologyProfile.Topology.TopologicalNode"
+    )
+    base_mod = importlib.import_module(
+        "generated.EuropeanStandards.CommonGridModelExchangeStandard.EquipmentProfile.Core.IdentifiedObject"
+    )
     cls = tn_mod.TopologicalNode
     base = base_mod.IdentifiedObject
     assert issubclass(cls, base)

--- a/tests/test_smallgrid_nodebreaker.py
+++ b/tests/test_smallgrid_nodebreaker.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import importlib
+import shutil
+
+import cgmes.runtime
+from cgmes.runtime import parse_file
+from cgmes_generator import generate_dataclasses
+import runtime.base as rt_base
+
+TopologicalNode = None
+
+DATA_DIR = Path("cgmes-models/v24/SmallGrid/node-breaker")
+XML_FILE = DATA_DIR / "SmallGridTestConfiguration_BC_TP_v3.0.0.xml"
+
+
+def setup_module(module):
+    shutil.rmtree("generated", ignore_errors=True)
+    generate_dataclasses(
+        "cgmes-models/v24/ENTSOE_CGMES_v2.4.15_7Aug2014.xml",
+        "generated",
+    )
+    global TopologicalNode
+    TopologicalNode = importlib.import_module(
+        "generated.EuropeanStandards.CommonGridModelExchangeStandard.TopologyProfile.Topology.TopologicalNode"
+    ).TopologicalNode
+    module._old_ns = rt_base.NS["cim"]
+    rt_base.NS["cim"] = "http://iec.ch/TC57/2013/CIM-schema-cim16#"
+    rt_base._SPEC_CACHE.pop(TopologicalNode, None)
+
+
+def teardown_module(module):
+    rt_base.NS["cim"] = module._old_ns
+    rt_base._SPEC_CACHE.pop(TopologicalNode, None)
+
+
+def test_parse_topological_nodes():
+    nodes = list(parse_file(XML_FILE, TopologicalNode))
+    assert len(nodes) == 115
+    assert all(n.BaseVoltage_id for n in nodes)
+
+
+def test_roundtrip_single():
+    node = next(parse_file(XML_FILE, TopologicalNode))
+    new_elem = cgmes.runtime.to_element(node)
+    node2 = parse_file.__wrapped__(new_elem, TopologicalNode)
+    assert node2.BaseVoltage_id == node.BaseVoltage_id

--- a/tests/test_smallgrid_nodebreaker.py
+++ b/tests/test_smallgrid_nodebreaker.py
@@ -1,10 +1,13 @@
 from pathlib import Path
 import importlib
 import shutil
+import subprocess
+import sys
+import os
+import tempfile
+import pathlib
 
-import cgmes.runtime
-from cgmes.runtime import parse_file
-from cgmes_generator import generate_dataclasses
+from cgmes.runtime import parse_file, to_element, parse_dataclass
 import runtime.base as rt_base
 
 TopologicalNode = None
@@ -15,10 +18,14 @@ XML_FILE = DATA_DIR / "SmallGridTestConfiguration_BC_TP_v3.0.0.xml"
 
 def setup_module(module):
     shutil.rmtree("generated", ignore_errors=True)
-    generate_dataclasses(
-        "cgmes-models/v24/ENTSOE_CGMES_v2.4.15_7Aug2014.xml",
-        "generated",
+    env = os.environ.copy()
+    env["PYTHONUTF8"] = "1"
+    subprocess.check_call(
+        [sys.executable, "-m", "cgmes_generator", "--rebuild"],
+        env=env,
+        cwd=pathlib.Path(__file__).parents[1],
     )
+    importlib.invalidate_caches()
     global TopologicalNode
     TopologicalNode = importlib.import_module(
         "generated.EuropeanStandards.CommonGridModelExchangeStandard.TopologyProfile.Topology.TopologicalNode"
@@ -41,6 +48,6 @@ def test_parse_topological_nodes():
 
 def test_roundtrip_single():
     node = next(parse_file(XML_FILE, TopologicalNode))
-    new_elem = cgmes.runtime.to_element(node)
-    node2 = parse_file.__wrapped__(new_elem, TopologicalNode)
+    new_elem = to_element(node)
+    node2 = parse_dataclass(new_elem, TopologicalNode)
     assert node2.BaseVoltage_id == node.BaseVoltage_id


### PR DESCRIPTION
## Summary
- expose runtime helpers via `cgmes` package
- validate and parse XML from the SmallGrid node-breaker example
- document how to run the integration test in the Quick Start section

## Testing
- `pytest -q`
- `python -m benchmarks.bench_dataset` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684233fa969c83259bf4dc6c75e04e20