### PR TITLE
GEN-101 equipment profile generation

### DIFF
--- a/cgmes_generator/meta.py
+++ b/cgmes_generator/meta.py
@@ -32,6 +32,7 @@ class ClassMeta:
     uml_id: Optional[str] = None
     links: List["LinkData"] = field(default_factory=list)
     is_abstract: bool = False
+    stereotype: Optional[str] = None
 
 
 @dataclass

--- a/cgmes_generator/parser/xmi.py
+++ b/cgmes_generator/parser/xmi.py
@@ -228,6 +228,15 @@ def parse_xmi(tree: etree._ElementTree) -> Tuple[
     for model in root.xpath(".//uml:Model", namespaces=NSMAP):
         walk(model, [])
 
+    for el in root.xpath('.//element[@xmi:type="uml:Class"]', namespaces=NSMAP):
+        cid = el.get("xmi:idref")
+        props = el.find("properties")
+        if cid and props is not None:
+            stereo = props.get("stereotype")
+            if stereo and cid in class_by_id:
+                for meta in class_by_id[cid]:
+                    meta.stereotype = stereo
+
     links = collect_links(root, class_by_id)
 
     for assoc in root.xpath(

--- a/cgmes_generator/simple_gen.py
+++ b/cgmes_generator/simple_gen.py
@@ -5,6 +5,7 @@ from typing import Dict, Iterable
 
 from .parser import load_xmi, parse_xmi
 from .meta import ClassMeta, Attribute
+from .api import generate_dataclasses
 
 TEMPLATES = {
     "IdentifiedObject": (
@@ -110,3 +111,27 @@ def rebuild(out_dir: Path = Path("generated/topology")) -> None:
         else:
             src = _gen_class(meta)
             (out_dir / f"{name}.py").write_text(src, encoding="utf-8")
+
+    eq_dir = Path("generated/equipment")
+    _rebuild_equipment(eq_dir, classes)
+
+    generate_dataclasses(XMI_PATH, Path("generated"))
+
+
+def _rebuild_equipment(out: Path, classes: Dict[tuple[str, ...], ClassMeta]) -> None:
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "__init__.py").touch()
+    (out / "IdentifiedObject.py").write_text(
+        TEMPLATES["IdentifiedObject"], encoding="utf-8"
+    )
+    targets = [
+        m
+        for m in classes.values()
+        if m.stereotype == "Equipment" or "EquipmentProfile" in ".".join(m.pkg_parts)
+    ]
+    for meta in sorted(targets, key=lambda m: m.name):
+        if meta.name in TEMPLATES:
+            (out / f"{meta.name}.py").write_text(TEMPLATES[meta.name], encoding="utf-8")
+        else:
+            src = _gen_class(meta)
+            (out / f"{meta.name}.py").write_text(src, encoding="utf-8")

--- a/tests/test_smallgrid_eq.py
+++ b/tests/test_smallgrid_eq.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import importlib
+import shutil
+import subprocess
+import sys
+import os
+import pathlib
+
+from cgmes.runtime import parse_dataset
+import runtime.base as rt_base
+
+PowerTransformer = None
+PowerTransformerEnd = None
+
+DATA_DIR = Path("cgmes-models/v24/SmallGrid/node-breaker")
+XML_FILE = DATA_DIR / "SmallGridTestConfiguration_BC_EQ_v3.0.0.xml"
+
+
+def setup_module(module):
+    shutil.rmtree("generated", ignore_errors=True)
+    env = os.environ.copy()
+    env["PYTHONUTF8"] = "1"
+    subprocess.check_call(
+        [sys.executable, "-m", "cgmes_generator", "--rebuild"],
+        env=env,
+        cwd=pathlib.Path(__file__).parents[1],
+    )
+    importlib.invalidate_caches()
+    global PowerTransformer, PowerTransformerEnd
+    PowerTransformer = importlib.import_module(
+        "generated.equipment.PowerTransformer"
+    ).PowerTransformer
+    PowerTransformerEnd = importlib.import_module(
+        "generated.equipment.PowerTransformerEnd"
+    ).PowerTransformerEnd
+    module._old_ns = rt_base.NS["cim"]
+    rt_base.NS["cim"] = "http://iec.ch/TC57/2013/CIM-schema-cim16#"
+    rt_base._SPEC_CACHE.pop(PowerTransformer, None)
+    rt_base._SPEC_CACHE.pop(PowerTransformerEnd, None)
+
+
+def teardown_module(module):
+    rt_base.NS["cim"] = module._old_ns
+    rt_base._SPEC_CACHE.pop(PowerTransformer, None)
+    rt_base._SPEC_CACHE.pop(PowerTransformerEnd, None)
+
+
+def test_parse_power_transformers():
+    data = parse_dataset(str(XML_FILE), [PowerTransformer, PowerTransformerEnd])
+    assert len(data[PowerTransformer]) == 10
+    assert all(pe.PowerTransformer_id for pe in data[PowerTransformerEnd])


### PR DESCRIPTION
## Summary
- extend metadata with stereotype attribute
- parse stereotypes in XMI loader
- generate Equipment profile classes under `generated/equipment`
- call full generator for EuropeanStandards during rebuild
- add integration test for EQ dataset

## Testing
- `pytest -k smallgrid_eq -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842826477cc8325996352f36cb38209