### PR TITLE
RT-201 add SmallGrid roundtrip test

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ pytest                                    # ▶ all tests incl. pylint
 pytest -k smallgrid                       # ▶ integration test on sample model
 python -m cgmes.export cgmes-models/v24/SmallGrid/node-breaker out/
 # inspect out/*.xml in EA / GridCal
+pytest -k smallgrid_bundle_roundtrip
+# \u21d2 creates export/roundtrip/Equipment.xml, Topology.xml, …
 ```
 
 ```python

--- a/runtime/base.py
+++ b/runtime/base.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 """Minimal runtime helpers for CGMES dataclasses."""
-
 from dataclasses import fields
 from typing import Any, Dict, Iterator, List, Tuple, Type, TypeVar
-
 from lxml import etree
-
 
 NS = {
     "cim": "http://iec.ch/TC57/2013/CIM-schema-cim#",
@@ -15,8 +12,33 @@ NS = {
 
 T = TypeVar("T")
 
-
 _SPEC_CACHE: Dict[Type[Any], List[Tuple[str | None, str | None, str]]] = {}
+_ALL_CLASSES: List[Type[Any]] | None = None
+
+
+def _load_all_classes() -> List[Type[Any]]:
+    """Return all generated dataclasses lazily."""
+    global _ALL_CLASSES
+    if _ALL_CLASSES is not None:
+        return _ALL_CLASSES
+    from importlib import import_module
+    import pkgutil
+    from dataclasses import is_dataclass
+
+    try:
+        import generated
+    except ModuleNotFoundError:  # pragma: no cover - generator not run yet
+        _ALL_CLASSES = []
+        return _ALL_CLASSES
+
+    classes: List[Type[Any]] = []
+    for info in pkgutil.walk_packages(generated.__path__, generated.__name__ + "."):
+        mod = import_module(info.name)
+        for obj in vars(mod).values():
+            if isinstance(obj, type) and is_dataclass(obj):
+                classes.append(obj)
+    _ALL_CLASSES = classes
+    return classes
 
 
 def _spec(cls: Type[Any]) -> List[Tuple[str | None, str | None, str]]:
@@ -102,7 +124,9 @@ def parse_file(path: str, cls: Type[T]) -> Iterator[T]:
         elem.clear()
 
 
-def parse_dataset(path: str, classes: List[Type[Any]]) -> Dict[Type[Any], List[Any]]:
+def parse_dataset(
+    path: str, classes: List[Type[Any]] | None = None
+) -> Dict[Type[Any], List[Any]]:
     """Parse *path* once and collect objects of ``classes``.
 
     Example
@@ -111,6 +135,8 @@ def parse_dataset(path: str, classes: List[Type[Any]]) -> Dict[Type[Any], List[A
     >>> len(data[TopologicalNode])
     10
     """
+    if classes is None:
+        classes = _load_all_classes()
     qname_map = {f"{{{NS['cim']}}}{cls.__name__}": cls for cls in classes}
     result: Dict[Type[Any], List[Any]] = {cls: [] for cls in classes}
     tags = tuple(qname_map)

--- a/tests/test_smallgrid_bundle_roundtrip.py
+++ b/tests/test_smallgrid_bundle_roundtrip.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import shutil
+import importlib
+import subprocess
+import sys
+import os
+import pathlib
+
+import pytest
+
+from cgmes.runtime import parse_dataset, export_dataset
+
+DATA_DIR = Path("cgmes-models/v24/SmallGrid/node-breaker")
+
+
+def setup_module(module):
+    shutil.rmtree("generated", ignore_errors=True)
+    env = os.environ.copy()
+    env["PYTHONUTF8"] = "1"
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "cgmes_generator",
+            "--rebuild",
+        ],
+        env=env,
+        cwd=pathlib.Path(__file__).parents[1],
+    )
+    importlib.invalidate_caches()
+
+
+@pytest.mark.parametrize("xml", sorted(DATA_DIR.glob("*.xml")))
+def test_roundtrip_all_profiles(xml):
+    objs = parse_dataset(xml)
+    assert objs, f"no objects parsed from {xml.name}"
+
+    out = Path("export/roundtrip")
+    out.mkdir(parents=True, exist_ok=True)
+    export_dataset(objs, out)
+
+    for prof in {cls.__module__.split(".")[-2] for cls in objs}:
+        f = out / f"{prof}.xml"
+        assert f.exists() and f.stat().st_size > 100, f"{f} missing/empty"


### PR DESCRIPTION
## Summary
- allow parse_dataset without class list by scanning generated packages
- test SmallGrid bundle roundtrip across all profiles
- document roundtrip pytest check in README

## Testing
- `pytest -k smallgrid_bundle_roundtrip -q`
- `pytest -q`
- `python -m benchmarks.perf` *(fails: No module named benchmarks.perf)*
- `python semantic_validator.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684822c0625083258ca67e4dfb1251bb